### PR TITLE
Add missing includes and consts for member functions

### DIFF
--- a/cybergear_driver_core/include/cybergear_driver_core/bounded_float_byte_converter.hpp
+++ b/cybergear_driver_core/include/cybergear_driver_core/bounded_float_byte_converter.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include <cstring>
 #include <algorithm>
 #include <array>
@@ -47,18 +49,18 @@ public:
     updateRange();
   }
 
-  float toClampedFloat(const float value)
+  float toClampedFloat(const float value) const
   {
     return std::max(min_, std::min(max_, value));
   }
 
-  uint16_t toDoubleByte(const float value)
+  uint16_t toDoubleByte(const float value) const
   {
     const float clamped_value = toClampedFloat(value);
     return static_cast<uint16_t>((clamped_value - min_) * byte_scale_);
   }
 
-  std::array<uint8_t, 2> toTwoBytes(const float value)
+  std::array<uint8_t, 2> toTwoBytes(const float value) const
   {
     const uint16_t scaled_double_byte = toDoubleByte(value);
     return {
@@ -66,7 +68,7 @@ public:
       static_cast<uint8_t>(scaled_double_byte & 0x00ff)};
   }
 
-  std::array<uint8_t, 4> toFourBytes(const float value)
+  std::array<uint8_t, 4> toFourBytes(const float value) const
   {
     constexpr size_t kArrayLength = 4;
     const float clamped_float = toClampedFloat(value);

--- a/cybergear_driver_core/include/cybergear_driver_core/bounded_float_byte_converter.hpp
+++ b/cybergear_driver_core/include/cybergear_driver_core/bounded_float_byte_converter.hpp
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <cstring>
 #include <algorithm>

--- a/cybergear_driver_core/include/cybergear_driver_core/cybergear_frame_id.hpp
+++ b/cybergear_driver_core/include/cybergear_driver_core/cybergear_frame_id.hpp
@@ -52,103 +52,103 @@ public:
 
   ~CybergearFrameId() {}
 
-  bool isInfo(const uint32_t id)
+  bool isInfo(const uint32_t id) const
   {
     const uint8_t frame_type_id = (id & FRAME_TYPE_MASK) >> FRAME_TYPE_OFFSET;
     return frame_type_id == commands::INFO;
   }
 
-  bool isFeedback(const uint32_t id)
+  bool isFeedback(const uint32_t id) const
   {
     const uint8_t frame_type_id = (id & FRAME_TYPE_MASK) >> FRAME_TYPE_OFFSET;
     return frame_type_id == commands::FEEDBACK;
   }
 
-  bool isFault(const uint32_t id)
+  bool isFault(const uint32_t id) const
   {
     const uint8_t frame_type_id = (id & FRAME_TYPE_MASK) >> FRAME_TYPE_OFFSET;
     return frame_type_id == commands::FAULT_FEEDBACK;
   }
 
-  uint8_t getFrameId(const uint32_t id)
+  uint8_t getFrameId(const uint32_t id) const
   {
     return (id & DEVICE_ID_MASK) >> DEVICE_ID_OFFSET;
   }
 
-  bool isDevice(const uint32_t id)
+  bool isDevice(const uint32_t id) const
   {
     return getFrameId(id) == device_id_;
   }
 
-  bool hasError(const uint32_t id)
+  bool hasError(const uint32_t id) const
   {
     return (id & FEEDBACK_ERROR_MASK) > 0;
   }
 
-  bool isResetMode(const uint32_t id)
+  bool isResetMode(const uint32_t id) const
   {
     const uint8_t mode = (id & FEEDBACK_MODE_STATE_MASK) >> MODE_STATE_OFFSET;
     return mode == feedback_mode_state::RESET;
   }
 
-  bool isCaliMode(const uint32_t id)
+  bool isCaliMode(const uint32_t id) const
   {
     const uint8_t mode = (id & FEEDBACK_MODE_STATE_MASK) >> MODE_STATE_OFFSET;
     return mode == feedback_mode_state::CALI;
   }
 
-  bool isRunningMode(const uint32_t id)
+  bool isRunningMode(const uint32_t id) const
   {
     const uint8_t mode = (id & FEEDBACK_MODE_STATE_MASK) >> MODE_STATE_OFFSET;
     return mode == feedback_mode_state::RUN;
   }
 
-  uint32_t getInfoId(const uint8_t device_id)
+  uint32_t getInfoId(const uint8_t device_id) const
   {
     return frameId(device_id, commands::INFO, primary_id_);
   }
 
-  uint32_t getInfoId()
+  uint32_t getInfoId() const
   {
     return getInfoId(device_id_);
   }
 
-  uint32_t getCommandId(const uint16_t effort_limit)
+  uint32_t getCommandId(const uint16_t effort_limit) const
   {
     return frameId(device_id_, commands::COMMAND, effort_limit);
   }
 
-  uint32_t getFeedbackId()
+  uint32_t getFeedbackId() const
   {
     return frameId(device_id_, commands::FEEDBACK, primary_id_);
   }
 
-  uint32_t getEnableTorqueId()
+  uint32_t getEnableTorqueId() const
   {
     return frameId(device_id_, commands::ENABLE_TORQUE, primary_id_);
   }
 
-  uint32_t getResetTorqueId()
+  uint32_t getResetTorqueId() const
   {
     return frameId(device_id_, commands::RESET_TORQUE, primary_id_);
   }
 
-  uint32_t getZeroPositionId()
+  uint32_t getZeroPositionId() const
   {
     return frameId(device_id_, commands::ZEROING, primary_id_);
   }
 
-  uint32_t getChangeDeviceId(const uint8_t change_id)
+  uint32_t getChangeDeviceId(const uint8_t change_id) const
   {
     return frameId(device_id_, commands::CHANGE_DEVICE_ID, change_id << 8 | primary_id_);
   }
 
-  uint32_t getReadParameterId()
+  uint32_t getReadParameterId() const
   {
     return frameId(device_id_, commands::READ_PARAMETER, primary_id_);
   }
 
-  uint32_t getWriteParameterId()
+  uint32_t getWriteParameterId() const
   {
     return frameId(device_id_, commands::WRITE_PARAMETER, primary_id_);
   }
@@ -157,7 +157,7 @@ private:
   const uint8_t device_id_;
   const uint8_t primary_id_;
 
-  uint32_t frameId(const uint8_t dev_id, const uint8_t cmd_id, const uint16_t opt)
+  uint32_t frameId(const uint8_t dev_id, const uint8_t cmd_id, const uint16_t opt) const
   {
     return static_cast<uint32_t>(cmd_id << 24 | opt << 8 | dev_id);
   }

--- a/cybergear_driver_core/include/cybergear_driver_core/cybergear_packet.hpp
+++ b/cybergear_driver_core/include/cybergear_driver_core/cybergear_packet.hpp
@@ -200,22 +200,22 @@ public:
     return createChangeRunMode(run_modes::CURRENT);
   }
 
-  float persePosition(const CanData & data) const
+  float parsePosition(const CanData & data) const
   {
     return anguler_position_converter_->toFloat<8>(data, 0);
   }
 
-  float perseVelocity(const CanData & data) const
+  float parseVelocity(const CanData & data) const
   {
     return anguler_velocity_converter_->toFloat<8>(data, 2);
   }
 
-  float perseEffort(const CanData & data) const
+  float parseEffort(const CanData & data) const
   {
     return anguler_effort_converter_->toFloat<8>(data, 4);
   }
 
-  float perseTemperature(const CanData & data) const
+  float parseTemperature(const CanData & data) const
   {
     return temperature_converter_->toFloat<8>(data, 6);
   }

--- a/cybergear_driver_core/include/cybergear_driver_core/cybergear_packet.hpp
+++ b/cybergear_driver_core/include/cybergear_driver_core/cybergear_packet.hpp
@@ -24,7 +24,6 @@
 
 #include <algorithm>
 #include <array>
-#include <memory>
 
 #include "bounded_float_byte_converter.hpp"
 #include "cybergear_frame_id.hpp"
@@ -59,92 +58,75 @@ struct CanFrame
   CanData data;
 };
 
-using CanFrameUniquePtr = std::unique_ptr<CanFrame>;
-
 class CybergearPacket
 {
 public:
   explicit CybergearPacket(const CybergearPacketParam & param)
-  : frame_id_(nullptr),
-    anguler_position_converter_(nullptr),
-    anguler_velocity_converter_(nullptr),
-    anguler_effort_converter_(nullptr),
-    pid_kp_converter_(nullptr),
-    pid_kd_converter_(nullptr),
-    motor_current_converter_(nullptr),
-    temperature_converter_(nullptr)
-  {
-    frame_id_ = std::make_unique<CybergearFrameId>(param.device_id, param.primary_id);
-    anguler_position_converter_ =
-      std::make_unique<BoundedFloatByteConverter>(param.max_position, param.min_position);
-    anguler_velocity_converter_ =
-      std::make_unique<BoundedFloatByteConverter>(param.max_velocity, param.min_velocity);
-    anguler_effort_converter_ =
-      std::make_unique<BoundedFloatByteConverter>(param.max_effort, param.min_effort);
-    pid_kp_converter_ =
-      std::make_unique<BoundedFloatByteConverter>(param.max_gain_kp, param.min_gain_kp);
-    pid_kd_converter_ =
-      std::make_unique<BoundedFloatByteConverter>(param.max_gain_kd, param.min_gain_kd);
-    motor_current_converter_ =
-      std::make_unique<BoundedFloatByteConverter>(param.max_current, param.min_current);
-    temperature_converter_ = std::make_unique<ScaledFloatByteConverter>(param.temperature_scale);
+  : frame_id_(param.device_id, param.primary_id),
+    anguler_position_converter_(param.max_position, param.min_position),
+    anguler_velocity_converter_(param.max_velocity, param.min_velocity),
+    anguler_effort_converter_(param.max_effort, param.min_effort),
+    pid_kp_converter_(param.max_gain_kp, param.min_gain_kp),
+    pid_kd_converter_(param.max_gain_kd, param.min_gain_kd),
+    motor_current_converter_(param.max_current, param.min_current),
+    temperature_converter_(param.temperature_scale) {
   }
 
   ~CybergearPacket() {}
 
   CybergearFrameId frameId()
   {
-    return *frame_id_;
+    return frame_id_;
   }
 
-  CanFrameUniquePtr createGetParamCommand(const uint16_t param_index)
+  CanFrame createGetParamCommand(const uint16_t param_index)
   {
-    auto can_frame = std::make_unique<CanFrame>();
-    can_frame->id = frame_id_->getReadParameterId();
+    CanFrame can_frame;
+    can_frame.id = frame_id_.getReadParameterId();
     return can_frame;
   }
 
-  CanFrameUniquePtr createMoveCommand(const MoveParam & param)
+  CanFrame createMoveCommand(const MoveParam & param)
   {
-    auto can_frame = std::make_unique<CanFrame>();
+    CanFrame can_frame;
 
-    const auto cmd_pos = anguler_position_converter_->toTwoBytes(param.position);
-    const auto cmd_vel = anguler_velocity_converter_->toTwoBytes(param.velocity);
-    const auto cmd_effort = anguler_effort_converter_->toDoubleByte(param.effort);
-    const auto kp_gain = pid_kp_converter_->toTwoBytes(param.kp);
-    const auto kd_gain = pid_kd_converter_->toTwoBytes(param.kd);
+    const auto cmd_pos = anguler_position_converter_.toTwoBytes(param.position);
+    const auto cmd_vel = anguler_velocity_converter_.toTwoBytes(param.velocity);
+    const auto cmd_effort = anguler_effort_converter_.toDoubleByte(param.effort);
+    const auto kp_gain = pid_kp_converter_.toTwoBytes(param.kp);
+    const auto kd_gain = pid_kd_converter_.toTwoBytes(param.kd);
 
-    std::copy(cmd_pos.cbegin(), cmd_pos.cend(), can_frame->data.begin());
-    std::copy(cmd_vel.cbegin(), cmd_vel.cend(), can_frame->data.begin() + 2);
-    std::copy(kp_gain.cbegin(), kp_gain.cend(), can_frame->data.begin() + 4);
-    std::copy(kd_gain.cbegin(), kd_gain.cend(), can_frame->data.begin() + 6);
+    std::copy(cmd_pos.cbegin(), cmd_pos.cend(), can_frame.data.begin());
+    std::copy(cmd_vel.cbegin(), cmd_vel.cend(), can_frame.data.begin() + 2);
+    std::copy(kp_gain.cbegin(), kp_gain.cend(), can_frame.data.begin() + 4);
+    std::copy(kd_gain.cbegin(), kd_gain.cend(), can_frame.data.begin() + 6);
 
-    can_frame->id = frame_id_->getCommandId(cmd_effort);
-
-    return can_frame;
-  }
-
-  CanFrameUniquePtr createWriteParameter(const uint16_t index, const std::array<uint8_t, 4> & param)
-  {
-    auto can_frame = std::make_unique<CanFrame>();
-
-    can_frame->data[0] = index & 0x00ff;
-    can_frame->data[1] = index >> 8;
-    std::copy(param.cbegin(), param.cend(), can_frame->data.begin() + 4);
-
-    can_frame->id = frame_id_->getWriteParameterId();
+    can_frame.id = frame_id_.getCommandId(cmd_effort);
 
     return can_frame;
   }
 
-  CanFrameUniquePtr createChangeRunMode(const uint8_t mode_id)
+  CanFrame createWriteParameter(const uint16_t index, const std::array<uint8_t, 4> & param)
+  {
+    CanFrame can_frame;
+
+    can_frame.data[0] = index & 0x00ff;
+    can_frame.data[1] = index >> 8;
+    std::copy(param.cbegin(), param.cend(), can_frame.data.begin() + 4);
+
+    can_frame.id = frame_id_.getWriteParameterId();
+
+    return can_frame;
+  }
+
+  CanFrame createChangeRunMode(const uint8_t mode_id)
   {
     std::array<uint8_t, 4> param;
     param[0] = mode_id;
     return createWriteParameter(ram_parameters::RUN_MODE, param);
   }
 
-  CanFrameUniquePtr createPositionWithGainCommand(
+  CanFrame createPositionWithGainCommand(
     const float position, const float kp, const float kd)
   {
     MoveParam param;
@@ -154,80 +136,80 @@ public:
     return createMoveCommand(param);
   }
 
-  CanFrameUniquePtr createZeroPosition()
+  CanFrame createZeroPosition()
   {
-    auto can_frame = std::make_unique<CanFrame>();
-    can_frame->data[0] = 1;
-    can_frame->id = frame_id_->getZeroPositionId();
+    CanFrame can_frame;
+    can_frame.data[0] = 1;
+    can_frame.id = frame_id_.getZeroPositionId();
     return can_frame;
   }
 
-  CanFrameUniquePtr createPositionCommand(const float position)
+  CanFrame createPositionCommand(const float position)
   {
-    const auto param = anguler_position_converter_->toFourBytes(position);
+    const auto param = anguler_position_converter_.toFourBytes(position);
     return createWriteParameter(ram_parameters::DEST_POSITION_REF, param);
   }
 
-  CanFrameUniquePtr createVelocityCommand(const float velocity)
+  CanFrame createVelocityCommand(const float velocity)
   {
-    const auto param = anguler_velocity_converter_->toFourBytes(velocity);
+    const auto param = anguler_velocity_converter_.toFourBytes(velocity);
     return createWriteParameter(ram_parameters::SPEED_REF, param);
   }
 
-  CanFrameUniquePtr createCurrentCommand(const float current)
+  CanFrame createCurrentCommand(const float current)
   {
-    const auto param = motor_current_converter_->toFourBytes(current);
+    const auto param = motor_current_converter_.toFourBytes(current);
     return createWriteParameter(ram_parameters::IQ_REF, param);
   }
 
-  CanFrameUniquePtr createChangeToOperationModeCommand()
+  CanFrame createChangeToOperationModeCommand()
   {
     return createChangeRunMode(run_modes::OPERATION);
   }
 
-  CanFrameUniquePtr createChangeToPositionModeCommand()
+  CanFrame createChangeToPositionModeCommand()
   {
     return createChangeRunMode(run_modes::POSITION);
   }
 
-  CanFrameUniquePtr createChangeToVelocityModeCommand()
+  CanFrame createChangeToVelocityModeCommand()
   {
     return createChangeRunMode(run_modes::SPEED);
   }
 
-  CanFrameUniquePtr createChangeToCurrentModeCommand()
+  CanFrame createChangeToCurrentModeCommand()
   {
     return createChangeRunMode(run_modes::CURRENT);
   }
 
   float parsePosition(const CanData & data) const
   {
-    return anguler_position_converter_->toFloat<8>(data, 0);
+    return anguler_position_converter_.toFloat<8>(data, 0);
   }
 
   float parseVelocity(const CanData & data) const
   {
-    return anguler_velocity_converter_->toFloat<8>(data, 2);
+    return anguler_velocity_converter_.toFloat<8>(data, 2);
   }
 
   float parseEffort(const CanData & data) const
   {
-    return anguler_effort_converter_->toFloat<8>(data, 4);
+    return anguler_effort_converter_.toFloat<8>(data, 4);
   }
 
   float parseTemperature(const CanData & data) const
   {
-    return temperature_converter_->toFloat<8>(data, 6);
+    return temperature_converter_.toFloat<8>(data, 6);
   }
 
 private:
-  std::unique_ptr<CybergearFrameId> frame_id_;
-  std::unique_ptr<BoundedFloatByteConverter> anguler_position_converter_;
-  std::unique_ptr<BoundedFloatByteConverter> anguler_velocity_converter_;
-  std::unique_ptr<BoundedFloatByteConverter> anguler_effort_converter_;
-  std::unique_ptr<BoundedFloatByteConverter> pid_kp_converter_;
-  std::unique_ptr<BoundedFloatByteConverter> pid_kd_converter_;
-  std::unique_ptr<BoundedFloatByteConverter> motor_current_converter_;
-  std::unique_ptr<ScaledFloatByteConverter> temperature_converter_;
+  CybergearFrameId frame_id_;
+  BoundedFloatByteConverter anguler_position_converter_;
+  BoundedFloatByteConverter anguler_velocity_converter_;
+  BoundedFloatByteConverter anguler_effort_converter_;
+  BoundedFloatByteConverter pid_kp_converter_;
+  BoundedFloatByteConverter pid_kd_converter_;
+  BoundedFloatByteConverter motor_current_converter_;
+  ScaledFloatByteConverter temperature_converter_;
 };
 }  // namespace cybergear_driver_core

--- a/cybergear_driver_core/include/cybergear_driver_core/protocol_constant.hpp
+++ b/cybergear_driver_core/include/cybergear_driver_core/protocol_constant.hpp
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace cybergear_driver_core
 {

--- a/cybergear_driver_core/include/cybergear_driver_core/protocol_constant.hpp
+++ b/cybergear_driver_core/include/cybergear_driver_core/protocol_constant.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 namespace cybergear_driver_core
 {
 namespace commands

--- a/cybergear_driver_core/include/cybergear_driver_core/scaled_float_byte_converter.hpp
+++ b/cybergear_driver_core/include/cybergear_driver_core/scaled_float_byte_converter.hpp
@@ -32,9 +32,8 @@ class ScaledFloatByteConverter
 {
 public:
   explicit ScaledFloatByteConverter(const float scale)
-  {
-    setScale(scale);
-  }
+  : scale_(scale)
+  {}
 
   ~ScaledFloatByteConverter() {}
 

--- a/cybergear_driver_core/include/cybergear_driver_core/scaled_float_byte_converter.hpp
+++ b/cybergear_driver_core/include/cybergear_driver_core/scaled_float_byte_converter.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 
 namespace cybergear_driver_core
 {

--- a/cybergear_socketcan_driver/src/cybergear_default_driver_node.cpp
+++ b/cybergear_socketcan_driver/src/cybergear_default_driver_node.cpp
@@ -88,8 +88,8 @@ void CybergearDefaultDriverNode::sendCanFrameFromTrajectoryCallback(
   move_param.kd = static_cast<float>(this->params().pid_gain.kd);
 
   const auto can_frame = this->packet().createMoveCommand(move_param);
-  std::copy(can_frame->data.cbegin(), can_frame->data.cend(), msg.data.begin());
-  msg.id = can_frame->id;
+  std::copy(can_frame.data.cbegin(), can_frame.data.cend(), msg.data.begin());
+  msg.id = can_frame.id;
 }
 
 void CybergearDefaultDriverNode::sendCanFrameFromSetpointCallback(
@@ -104,15 +104,15 @@ void CybergearDefaultDriverNode::sendCanFrameFromSetpointCallback(
   move_param.kd = static_cast<float>(this->params().pid_gain.kd);
 
   const auto can_frame = this->packet().createMoveCommand(move_param);
-  std::copy(can_frame->data.cbegin(), can_frame->data.cend(), msg.data.begin());
-  msg.id = can_frame->id;
+  std::copy(can_frame.data.cbegin(), can_frame.data.cend(), msg.data.begin());
+  msg.id = can_frame.id;
 }
 
 void CybergearDefaultDriverNode::sendChangeRunModeCallback(can_msgs::msg::Frame & msg)
 {
   const auto can_frame = this->packet().createChangeToOperationModeCommand();
-  std::copy(can_frame->data.cbegin(), can_frame->data.cend(), msg.data.begin());
-  msg.id = can_frame->id;
+  std::copy(can_frame.data.cbegin(), can_frame.data.cend(), msg.data.begin());
+  msg.id = can_frame.id;
 }
 }  // namespace cybergear_socketcan_driver
 

--- a/cybergear_socketcan_driver/src/cybergear_position_driver_node.cpp
+++ b/cybergear_socketcan_driver/src/cybergear_position_driver_node.cpp
@@ -21,7 +21,6 @@
 // SOFTWARE.
 
 #include <cmath>
-#include <vector>
 
 #include <can_msgs/msg/frame.hpp>
 #include <cybergear_socketcan_driver/single_joint_trajectory_points.hpp>
@@ -84,23 +83,23 @@ void CybergearPositionDriverNode::sendCanFrameFromTrajectoryCallback(
     position = last_sense_anguler_position_;
   }
   const auto can_frame = this->packet().createPositionCommand(position);
-  std::copy(can_frame->data.cbegin(), can_frame->data.cend(), msg.data.begin());
-  msg.id = can_frame->id;
+  std::copy(can_frame.data.cbegin(), can_frame.data.cend(), msg.data.begin());
+  msg.id = can_frame.id;
 }
 
 void CybergearPositionDriverNode::sendCanFrameFromSetpointCallback(
   can_msgs::msg::Frame & msg, const cybergear_driver_msgs::msg::SetpointStamped & setpoint_msg)
 {
   const auto can_frame = this->packet().createPositionCommand(setpoint_msg.point.position);
-  std::copy(can_frame->data.cbegin(), can_frame->data.cend(), msg.data.begin());
-  msg.id = can_frame->id;
+  std::copy(can_frame.data.cbegin(), can_frame.data.cend(), msg.data.begin());
+  msg.id = can_frame.id;
 }
 
 void CybergearPositionDriverNode::sendChangeRunModeCallback(can_msgs::msg::Frame & msg)
 {
   const auto can_frame = this->packet().createChangeToPositionModeCommand();
-  std::copy(can_frame->data.cbegin(), can_frame->data.cend(), msg.data.begin());
-  msg.id = can_frame->id;
+  std::copy(can_frame.data.cbegin(), can_frame.data.cend(), msg.data.begin());
+  msg.id = can_frame.id;
 }
 }  // namespace cybergear_socketcan_driver
 

--- a/cybergear_socketcan_driver/src/cybergear_socketcan_driver_node.cpp
+++ b/cybergear_socketcan_driver/src/cybergear_socketcan_driver_node.cpp
@@ -22,14 +22,12 @@
 
 #include "cybergear_socketcan_driver_node.hpp"
 
+#include <cstdint>
 #include <algorithm>
-#include <array>
 #include <chrono>
 #include <cmath>
 #include <functional>
-#include <limits>
 #include <memory>
-#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -204,8 +202,8 @@ void CybergearSocketCanDriverNode::sendCanFrameFromSetpointCallback(
 void CybergearSocketCanDriverNode::sendChangeRunModeCallback(can_msgs::msg::Frame & msg)
 {
   const auto can_frame = packet_->createChangeToOperationModeCommand();
-  std::copy(can_frame->data.cbegin(), can_frame->data.cend(), msg.data.begin());
-  msg.id = can_frame->id;
+  std::copy(can_frame.data.cbegin(), can_frame.data.cend(), msg.data.begin());
+  msg.id = can_frame.id;
 }
 
 // TODO(Naoki Takahashi) parse read ram parameter
@@ -478,8 +476,8 @@ void CybergearSocketCanDriverNode::sendZeroPosition()
   auto msg = std::make_unique<can_msgs::msg::Frame>();
   setDefaultCanFrame(msg);
   const auto can_frame = packet_->createZeroPosition();
-  std::copy(can_frame->data.cbegin(), can_frame->data.cend(), msg->data.begin());
-  msg->id = can_frame->id;
+  std::copy(can_frame.data.cbegin(), can_frame.data.cend(), msg->data.begin());
+  msg->id = can_frame.id;
   can_frame_publisher_->publish(std::move(msg));
 }
 }  // namespace cybergear_socketcan_driver

--- a/cybergear_socketcan_driver/src/cybergear_socketcan_driver_node.cpp
+++ b/cybergear_socketcan_driver/src/cybergear_socketcan_driver_node.cpp
@@ -208,7 +208,7 @@ void CybergearSocketCanDriverNode::sendChangeRunModeCallback(can_msgs::msg::Fram
   msg.id = can_frame->id;
 }
 
-// TODO(Naoki Takahashi) perse read ram parameter
+// TODO(Naoki Takahashi) parse read ram parameter
 void CybergearSocketCanDriverNode::subscribeCanFrameCallback(
   const can_msgs::msg::Frame::ConstSharedPtr & msg)
 {
@@ -396,9 +396,9 @@ void CybergearSocketCanDriverNode::procFeedbackPacket(const can_msgs::msg::Frame
 
     joint_state_msg->header = header_msg;
     joint_state_msg->name.push_back(params_->joint_name);
-    joint_state_msg->position.push_back(packet_->persePosition(msg.data));
-    joint_state_msg->velocity.push_back(packet_->perseVelocity(msg.data));
-    joint_state_msg->effort.push_back(packet_->perseEffort(msg.data));
+    joint_state_msg->position.push_back(packet_->parsePosition(msg.data));
+    joint_state_msg->velocity.push_back(packet_->parseVelocity(msg.data));
+    joint_state_msg->effort.push_back(packet_->parseEffort(msg.data));
 
     if (!last_subscribe_joint_state_) {
       last_subscribe_joint_state_ = std::make_unique<sensor_msgs::msg::JointState>();
@@ -413,7 +413,7 @@ void CybergearSocketCanDriverNode::procFeedbackPacket(const can_msgs::msg::Frame
     auto temperature_msg = std::make_unique<sensor_msgs::msg::Temperature>();
 
     temperature_msg->header = header_msg;
-    temperature_msg->temperature = packet_->perseTemperature(msg.data);
+    temperature_msg->temperature = packet_->parseTemperature(msg.data);
     temperature_msg->variance = 0.0;  // unknown
 
     procFeedbackTemperatureCallabck(*temperature_msg);

--- a/cybergear_socketcan_driver/src/cybergear_torque_driver_node.cpp
+++ b/cybergear_socketcan_driver/src/cybergear_torque_driver_node.cpp
@@ -67,8 +67,8 @@ void CybergearTorqueDriverNode::sendCanFrameFromTrajectoryCallback(
     effort = single_joint_trajectory.getLerpEffort(this->get_clock()->now());
   }
   const auto can_frame = this->packet().createCurrentCommand(getDestCurrent(effort));
-  std::copy(can_frame->data.cbegin(), can_frame->data.cend(), msg.data.begin());
-  msg.id = can_frame->id;
+  std::copy(can_frame.data.cbegin(), can_frame.data.cend(), msg.data.begin());
+  msg.id = can_frame.id;
 }
 
 void CybergearTorqueDriverNode::sendCanFrameFromSetpointCallback(
@@ -76,15 +76,15 @@ void CybergearTorqueDriverNode::sendCanFrameFromSetpointCallback(
 {
   const auto can_frame =
     this->packet().createCurrentCommand(getDestCurrent(setpoint_msg.point.effort));
-  std::copy(can_frame->data.cbegin(), can_frame->data.cend(), msg.data.begin());
-  msg.id = can_frame->id;
+  std::copy(can_frame.data.cbegin(), can_frame.data.cend(), msg.data.begin());
+  msg.id = can_frame.id;
 }
 
 void CybergearTorqueDriverNode::sendChangeRunModeCallback(can_msgs::msg::Frame & msg)
 {
   const auto can_frame = this->packet().createChangeToCurrentModeCommand();
-  std::copy(can_frame->data.cbegin(), can_frame->data.cend(), msg.data.begin());
-  msg.id = can_frame->id;
+  std::copy(can_frame.data.cbegin(), can_frame.data.cend(), msg.data.begin());
+  msg.id = can_frame.id;
 }
 
 float CybergearTorqueDriverNode::getDestCurrent(const float dest_torque)

--- a/cybergear_socketcan_driver/src/cybergear_velocity_driver_node.cpp
+++ b/cybergear_socketcan_driver/src/cybergear_velocity_driver_node.cpp
@@ -64,23 +64,23 @@ void CybergearVelocityDriverNode::sendCanFrameFromTrajectoryCallback(
     velocity = single_joint_trajectory.getLerpVelocity(this->get_clock()->now());
   }
   const auto can_frame = this->packet().createVelocityCommand(velocity);
-  std::copy(can_frame->data.cbegin(), can_frame->data.cend(), msg.data.begin());
-  msg.id = can_frame->id;
+  std::copy(can_frame.data.cbegin(), can_frame.data.cend(), msg.data.begin());
+  msg.id = can_frame.id;
 }
 
 void CybergearVelocityDriverNode::sendCanFrameFromSetpointCallback(
   can_msgs::msg::Frame & msg, const cybergear_driver_msgs::msg::SetpointStamped & setpoint_msg)
 {
   const auto can_frame = this->packet().createVelocityCommand(setpoint_msg.point.velocity);
-  std::copy(can_frame->data.cbegin(), can_frame->data.cend(), msg.data.begin());
-  msg.id = can_frame->id;
+  std::copy(can_frame.data.cbegin(), can_frame.data.cend(), msg.data.begin());
+  msg.id = can_frame.id;
 }
 
 void CybergearVelocityDriverNode::sendChangeRunModeCallback(can_msgs::msg::Frame & msg)
 {
   const auto can_frame = this->packet().createChangeToVelocityModeCommand();
-  std::copy(can_frame->data.cbegin(), can_frame->data.cend(), msg.data.begin());
-  msg.id = can_frame->id;
+  std::copy(can_frame.data.cbegin(), can_frame.data.cend(), msg.data.begin());
+  msg.id = can_frame.id;
 }
 }  // namespace cybergear_socketcan_driver
 


### PR DESCRIPTION
Some small things I found while working on my other PR.

One think I was also wondering about. Why are all members of `CybergearPacket` unique pointers?

https://github.com/NaokiTakahashi12/cybergear_ros2/blob/6af966674a414064089e343e69bf5d90a51a90ce/cybergear_driver_core/include/cybergear_driver_core/cybergear_packet.hpp#L224-L231

I mean, why not doing everything on the stack here?